### PR TITLE
Waiting on min cov param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
         run: shards install
 
       - name: Check code coverage
-        run: .github/workflows/coverage.sh 50
-        # run: .github/workflows/coverage.sh 90
-        # run: bin/crystal-coverage
+        # run: bin/crystal-coverage # TODO: Get min-cov param/feature added
+        run: .github/workflows/coverage.sh 50 # Low min-cove to help pass CI
+        # run: .github/workflows/coverage.sh 90 # High min-cove to help fail CI
 
       - name: Check formatting
         run: crystal tool format --check src spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
         run: shards install
 
       - name: Check code coverage
-        # run: bin/crystal-coverage # TODO: Get min-cov param/feature added
-        run: .github/workflows/coverage.sh 50 # Low min-cove to help pass CI
-        # run: .github/workflows/coverage.sh 90 # High min-cove to help fail CI
+        # run: bin/crystal-coverage 90 # TODO: Waiting for min-cov param/feature to be added to 'bin/crystal-coverage'.
+        # run: .github/workflows/coverage.sh 50 # Low min-coverage to help pass CI.
+        run: .github/workflows/coverage.sh 90 # High min-coverage to help fail CI.
 
       - name: Check formatting
         run: crystal tool format --check src spec


### PR DESCRIPTION
I moved/refactored non-spec checks to the linux-only 'once_coverage_etc' and 'once_docs' sections ('jobs').

So, I bumped back up the min-coverage from `50` to `90` to force failure re min-coverage as of commit https://github.com/drhuffman12/crystal-coverage-example/pull/1/commits/45eea828f69b0e4b1d91f96a3e38c2e8a341644f .

Now, just **waiting on a 'minimum coverage' command-line option**, so that I can remove my `.github/workflows/coverage.sh` hacky script. (See issue: https://github.com/anykeyh/crystal-coverage/issues/19 .)